### PR TITLE
Feat: 다이어리 댓글 조회 구현 API #20

### DIFF
--- a/src/main/java/com/hanghae/sosohandiary/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/comment/controller/CommentController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class CommentController {
@@ -20,6 +22,12 @@ public class CommentController {
                                  @RequestBody CommentRequestDto requestDto,
                                  @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
         return commentService.createComment(id, requestDto, memberDetails.getMember());
+    }
+
+    @GetMapping("/detail/{detail-id}/comment")
+    public List<CommentResponseDto> getComment(@PathVariable(name = "detail-id")Long id,
+                                               @AuthenticationPrincipal MemberDetailsImpl memberDetails){
+        return commentService.getComment(id, memberDetails.getMember());
     }
 
     @PatchMapping("/detail/{detail-id}/comment/{comment-id}")

--- a/src/main/java/com/hanghae/sosohandiary/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/comment/dto/CommentResponseDto.java
@@ -1,6 +1,7 @@
 package com.hanghae.sosohandiary.domain.comment.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.hanghae.sosohandiary.domain.comment.entity.Comment;
 import com.hanghae.sosohandiary.domain.diary.entity.Diary;
 import com.hanghae.sosohandiary.domain.diarydetil.dto.DiaryDetailResponseDto;
 import com.hanghae.sosohandiary.domain.diarydetil.entity.DiaryDetail;
@@ -24,16 +25,33 @@ public class CommentResponseDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime modifiedAt;
 
+//    @Builder
+//    private CommentResponseDto(DiaryDetail diaryDetail,Member member, String comment) {
+//        id = diaryDetail.getId();
+//        this.comment = comment;
+//        this.member = member.getName();
+//        createdAt = diaryDetail.getCreatedAt();
+//        modifiedAt = diaryDetail.getModifiedAt();
+//    }
+
     @Builder
-    private CommentResponseDto(DiaryDetail diaryDetail,Member member, String comment) {
+    private CommentResponseDto(DiaryDetail diaryDetail,Member member, Comment comment) {
         id = diaryDetail.getId();
-        this.comment = comment;
+        this.comment = comment.getComment();
         this.member = member.getName();
         createdAt = diaryDetail.getCreatedAt();
         modifiedAt = diaryDetail.getModifiedAt();
     }
 
-    public static CommentResponseDto from(DiaryDetail diaryDetail, Member member,String comment) {
+//    public static CommentResponseDto from(DiaryDetail diaryDetail, Member member,String comment) {
+//        return CommentResponseDto.builder()
+//                .diaryDetail(diaryDetail)
+//                .member(member)
+//                .comment(comment)
+//                .build();
+//    }
+
+    public static CommentResponseDto from(DiaryDetail diaryDetail, Member member, Comment comment) {
         return CommentResponseDto.builder()
                 .diaryDetail(diaryDetail)
                 .member(member)

--- a/src/main/java/com/hanghae/sosohandiary/domain/comment/entity/Comment.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/comment/entity/Comment.java
@@ -31,16 +31,16 @@ public class Comment extends Timestamp {
     private Member member;
 
     @Column(nullable = false)
-    private String contents;
+    private String comment;
 
     @Builder
-    private Comment(DiaryDetail diaryDetail, Member member, String commentRequestDto) {
+    private Comment(DiaryDetail diaryDetail, Member member, CommentRequestDto commentRequestDto) {
         this.diaryDetail = diaryDetail;
-        this.contents = commentRequestDto;
+        this.comment = commentRequestDto.getComment();
         this.member = member;
     }
 
-    public static Comment of(DiaryDetail diaryDetail, Member member, String commentRequestDto) {
+    public static Comment of(DiaryDetail diaryDetail, Member member, CommentRequestDto commentRequestDto) {
         return Comment.builder()
                 .diaryDetail(diaryDetail)
                 .member(member)
@@ -49,7 +49,7 @@ public class Comment extends Timestamp {
     }
 
     public void update(String commentRequestDto){
-        this.contents=commentRequestDto;
+        this.comment=commentRequestDto;
     }
 
 }

--- a/src/main/java/com/hanghae/sosohandiary/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/comment/repository/CommentRepository.java
@@ -3,5 +3,9 @@ package com.hanghae.sosohandiary.domain.comment.repository;
 import com.hanghae.sosohandiary.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByOrderByCreatedAtDesc();
+
 }


### PR DESCRIPTION
## 📕 제목
Feat: 다이어리 댓글 조회 구현 API

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 작업내용1 : 다이어리 댓글 GET 등록
- [x] 작업내용2 : Create, Update, Delete의 Comment 타입 변경

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이사항1: Create, Update, Delete의 Comment 타입 변경