### PR TITLE
Refactor: 친구 추가 테이블 하나로 변경. 상태코드 추가. #87

### DIFF
--- a/src/main/java/com/hanghae/sosohandiary/domain/friend/controller/FriendRequestController.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/friend/controller/FriendRequestController.java
@@ -1,3 +1,4 @@
+/*
 package com.hanghae.sosohandiary.domain.friend.controller;
 
 import com.hanghae.sosohandiary.domain.friend.dto.FriendResponseDto;
@@ -34,3 +35,4 @@ public class FriendRequestController {
     }
 
 }
+*/

--- a/src/main/java/com/hanghae/sosohandiary/domain/friend/controller/FriendsListController.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/friend/controller/FriendsListController.java
@@ -16,6 +16,23 @@ import java.util.List;
 public class FriendsListController {
     private final FriendsListService friendsListService;
 
+    @PostMapping("/request/{member-id}")
+    public MessageDto createFriendRequest(@PathVariable(value = "member-id") Long id,
+                                          @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        return friendsListService.createFriendRequest(id, memberDetails.getMember());
+    }
+
+    @GetMapping("/request")
+    public List<FriendResponseDto> getFriendRequest(@AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        return friendsListService.getFriendRequest(memberDetails.getMember());
+    }
+
+    @PutMapping("/request/accept/{friendrequest-id}")
+    public MessageDto acceptFriend(@PathVariable(value = "friendrequest-id") Long id,
+                                         @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        return friendsListService.acceptFriend(id, memberDetails.getMember());
+    }
+
     @GetMapping("/list")
     public List<FriendResponseDto> getFriendList(@AuthenticationPrincipal MemberDetailsImpl memberDetails) {
         return friendsListService.getFriendList(memberDetails.getMember());

--- a/src/main/java/com/hanghae/sosohandiary/domain/friend/dto/FriendResponseDto.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/friend/dto/FriendResponseDto.java
@@ -1,21 +1,33 @@
 package com.hanghae.sosohandiary.domain.friend.dto;
 
+import com.hanghae.sosohandiary.domain.friend.entity.FriendList;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class FriendResponseDto {
 
-    private String nickName;
+    private Long friendListId;
+
+    private String friendNickName;
+    private String myNickname;
 
     @Builder
-    private FriendResponseDto(String nickName) {
-        this.nickName = nickName;
+    private FriendResponseDto(FriendList friendList) {
+        this.friendListId=friendList.getId();
+        this.myNickname = friendList.getFriend().getNickname();
+        this.friendNickName = friendList.getMember().getNickname();
+
     }
 
-    public static FriendResponseDto from(String nickName) {
+//    public static FriendResponseDto from(String nickName) {
+//        return FriendResponseDto.builder()
+//                .nickName(nickName)
+//                .build();
+//    }
+    public static FriendResponseDto from(FriendList friendList) {
         return FriendResponseDto.builder()
-                .nickName(nickName)
+                .friendList(friendList)
                 .build();
     }
 

--- a/src/main/java/com/hanghae/sosohandiary/domain/friend/entity/FriendList.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/friend/entity/FriendList.java
@@ -1,5 +1,6 @@
 package com.hanghae.sosohandiary.domain.friend.entity;
 
+import com.hanghae.sosohandiary.domain.friend.Enum.StatusFriend;
 import com.hanghae.sosohandiary.domain.member.entity.Member;
 import com.hanghae.sosohandiary.utils.entity.Timestamp;
 import lombok.AccessLevel;
@@ -26,17 +27,27 @@ public class FriendList extends Timestamp {
     @JoinColumn(name = "friend_id")
     private Member friend;
 
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private StatusFriend status;
+
     @Builder
-    private FriendList(Member member, Member friend) {
+    private FriendList(Member member, Member friend, StatusFriend status) {
         this.member = member;
         this.friend = friend;
+        this.status = status;
     }
 
-    public static FriendList of(Member member, Member friend) {
+    public static FriendList of(Member member, Member friend, StatusFriend status) {
         return FriendList.builder()
                 .member(member)
                 .friend(friend)
+                .status(status)
                 .build();
+    }
+
+    public void updateFriendStatus(StatusFriend status){
+        this.status=status;
     }
 
 }

--- a/src/main/java/com/hanghae/sosohandiary/domain/friend/repository/FriendListRepository.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/friend/repository/FriendListRepository.java
@@ -1,6 +1,8 @@
 package com.hanghae.sosohandiary.domain.friend.repository;
 
+import com.hanghae.sosohandiary.domain.friend.Enum.StatusFriend;
 import com.hanghae.sosohandiary.domain.friend.entity.FriendList;
+import com.hanghae.sosohandiary.domain.friend.entity.FriendRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -17,4 +19,6 @@ public interface FriendListRepository extends JpaRepository<FriendList, Long> {
 
     boolean existsByFriend_IdAndMember_Id(Long friendId, Long memberId);
 
+
+    List<FriendList> findByFriendIdAndStatusOrderByCreatedAtDesc(Long id, StatusFriend Status);
 }

--- a/src/main/java/com/hanghae/sosohandiary/domain/friend/service/FriendsListService.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/friend/service/FriendsListService.java
@@ -1,9 +1,12 @@
 package com.hanghae.sosohandiary.domain.friend.service;
 
+import com.hanghae.sosohandiary.domain.friend.Enum.StatusFriend;
 import com.hanghae.sosohandiary.domain.friend.dto.FriendResponseDto;
 import com.hanghae.sosohandiary.domain.friend.entity.FriendList;
+import com.hanghae.sosohandiary.domain.friend.entity.FriendRequest;
 import com.hanghae.sosohandiary.domain.friend.repository.FriendListRepository;
 import com.hanghae.sosohandiary.domain.member.entity.Member;
+import com.hanghae.sosohandiary.domain.member.repository.MemberRepository;
 import com.hanghae.sosohandiary.exception.ApiException;
 import com.hanghae.sosohandiary.exception.ErrorHandling;
 import com.hanghae.sosohandiary.utils.MessageDto;
@@ -20,13 +23,68 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class FriendsListService {
     private final FriendListRepository friendListRepository;
+    private final MemberRepository memberRepository;
+
+    public MessageDto createFriendRequest(Long id, Member member) {
+        if (member.getId().equals(id)) {
+            return new MessageDto("자기 자신을 추가할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        Member memberId = memberRepository.findById(member.getId()).orElseThrow(
+                () -> new ApiException(ErrorHandling.NOT_FOUND_USER)
+        );
+        Member friendId = memberRepository.findById(id).orElseThrow(
+                () -> new ApiException(ErrorHandling.NOT_FOUND_USER)
+        );
+        // 친구 요청 중복 체크
+        boolean isDuplicated = friendListRepository.existsByFriend_IdAndMember_Id(id, memberId.getId());
+        if (isDuplicated) {
+            return new MessageDto("이미 상대방에게 친구 요청 하였습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+
+        friendListRepository.save(FriendList.of(memberId, friendId, StatusFriend.PENDING));
+
+        return new MessageDto("친구요청 성공", HttpStatus.CREATED);
+
+    }
+
+    public List<FriendResponseDto> getFriendRequest(Member member) {
+        List<FriendList> friendRequestList = friendListRepository.findByFriendIdAndStatusOrderByCreatedAtDesc(member.getId(), StatusFriend.PENDING);
+        List<FriendResponseDto> myFriendResponseDtoList = new ArrayList<>();
+
+        for (FriendList friendRequest : friendRequestList) {
+            myFriendResponseDtoList.add(FriendResponseDto.from(friendRequest));
+        }
+        return myFriendResponseDtoList;
+    }
+
+    @Transactional
+    public MessageDto acceptFriend(Long id, Member member) {
+
+        FriendList friendAccept = friendListRepository.findById(id).orElseThrow(
+                () -> new ApiException(ErrorHandling.NOT_REQUEST)
+        );
+
+        Member memberId = memberRepository.findById(member.getId()).orElseThrow(
+                () -> new ApiException(ErrorHandling.NOT_FOUND_USER)
+        );
+        Member friendId = memberRepository.findById(friendAccept.getMember().getId()).orElseThrow(
+                () -> new ApiException(ErrorHandling.NOT_FOUND_USER)
+        );
+
+        friendAccept.updateFriendStatus(StatusFriend.ACCEPTED);
+
+        friendListRepository.save(FriendList.of(memberId, friendId, StatusFriend.ACCEPTED));
+        return new MessageDto("친구추가 성공", HttpStatus.ACCEPTED);
+    }
 
     public List<FriendResponseDto> getFriendList(Member member) {
-        List<FriendList> FriendLists = friendListRepository.findAllByMemberId(member.getId());
+        List<FriendList> friendAccept = friendListRepository.findByFriendIdAndStatusOrderByCreatedAtDesc(member.getId(), StatusFriend.ACCEPTED);
         List<FriendResponseDto> friendListResponseDtoList = new ArrayList<>();
 
-        for (FriendList friendList : FriendLists) {
-            friendListResponseDtoList.add(FriendResponseDto.from(friendList.getFriend().getNickname()));
+        for (FriendList friendList : friendAccept) {
+            friendListResponseDtoList.add(FriendResponseDto.from(friendList));
         }
         return friendListResponseDtoList;
     }
@@ -45,4 +103,7 @@ public class FriendsListService {
         friendListRepository.deleteByFriendIdAndMemberId(friendList.getMember().getId(), friendList.getFriend().getId());
         return MessageDto.of("친구 삭제 완료", HttpStatus.OK);
     }
+
+
+
 }

--- a/src/main/java/com/hanghae/sosohandiary/domain/friend/service/FriendsRequestService.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/friend/service/FriendsRequestService.java
@@ -1,3 +1,4 @@
+/*
 package com.hanghae.sosohandiary.domain.friend.service;
 
 import com.hanghae.sosohandiary.domain.friend.dto.FriendResponseDto;
@@ -93,3 +94,4 @@ public class FriendsRequestService {
     }
 
 }
+*/


### PR DESCRIPTION
## 📕 제목
Refactor: 친구 추가 테이블 하나로 변경. 상태코드 추가.
## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 작업내용1 : FriendList에 상태코드 및 Enum 클래스 추가
- [x] 작업내용2 : 친구요청, 친구조회의 전반적인 CRUD 로직 수정.

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이사항1 : 친구 조회, 친구 삭제 시 비정상적 동작.
- 특이사항2 : 🙏DTO 재정립 필요.