### PR TITLE
Feat: 메인페이지 - Private, Public 필터 페이지 만들기

### DIFF
--- a/src/main/java/com/hanghae/sosohandiary/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/diary/controller/DiaryController.java
@@ -47,6 +47,12 @@ public class DiaryController {
         return diaryService.findPrivateDiaryList(pageable, memberDetails.getMember());
     }
 
+    @GetMapping("/invite")
+    public PageCustom<DiaryResponseDto> diaryinvitedList(@PageableDefault(size = 5) Pageable pageable,
+                                                         @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        return diaryService.findInvitedDiaryList(pageable, memberDetails.getMember());
+    }
+
     @PatchMapping("/diary/{diary-id}")
     public DiaryResponseDto diaryModify(@PathVariable(name = "diary-id") Long id,
                                         @RequestPart(value = "title") DiaryRequestDto diaryRequestDto,

--- a/src/main/java/com/hanghae/sosohandiary/domain/diary/entity/Diary.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/diary/entity/Diary.java
@@ -1,7 +1,6 @@
 package com.hanghae.sosohandiary.domain.diary.entity;
 
 import com.hanghae.sosohandiary.domain.diary.dto.DiaryRequestDto;
-import com.hanghae.sosohandiary.domain.invite.entity.Invite;
 import com.hanghae.sosohandiary.domain.member.entity.Member;
 import com.hanghae.sosohandiary.utils.entity.Timestamp;
 import lombok.AccessLevel;
@@ -10,9 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
 
@@ -38,16 +34,15 @@ public class Diary extends Timestamp {
     @Enumerated(value = EnumType.STRING)
     private DiaryCondition diaryCondition;
 
-    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
-    private List<Invite> inviteDiaryList = new ArrayList<>();
+//    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
+//    private List<Invite> inviteDiaryList = new ArrayList<>();
 
     @Builder
-    private Diary(DiaryRequestDto diaryRequestDto, String uploadPath, Member member, List<Invite> inviteDiaryList) {
+    private Diary(DiaryRequestDto diaryRequestDto, String uploadPath, Member member) {
         title = diaryRequestDto.getTitle();
         this.img = uploadPath;
         this.member = member;
         this.diaryCondition = diaryRequestDto.getDiaryCondition();
-        this.inviteDiaryList = inviteDiaryList;
     }
 
     public static Diary of(DiaryRequestDto diaryRequestDto, String uploadPath, Member member) {
@@ -57,14 +52,6 @@ public class Diary extends Timestamp {
                 .member(member)
                 .build();
     }
-//
-//    public static Diary of(DiaryRequestDto diaryRequestDto, String uploadPath, Member member) {
-//        return Diary.builder()
-//                .diaryRequestDto(diaryRequestDto)
-//                .uploadPath(uploadPath)
-//                .member(member)
-//                .build();
-//    }
 
     public static Diary of(DiaryRequestDto diaryRequestDto, Member member) {
         return Diary.builder()
@@ -78,8 +65,5 @@ public class Diary extends Timestamp {
         this.img = uploadPath;
     }
 
-    public void setInviteDiaryList(Invite invite) {
-        inviteDiaryList.add(invite);
-    }
 
 }

--- a/src/main/java/com/hanghae/sosohandiary/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/diary/repository/DiaryRepository.java
@@ -17,4 +17,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Page<Diary> findAllByDiaryConditionOrderByModifiedAtDesc(Pageable pageable, DiaryCondition condition);
     Page<Diary> findAllByMemberIdAndDiaryConditionOrderByModifiedAtDesc(Pageable pageable, Long id, DiaryCondition condition);
     Page<Diary> findAllByOrderByModifiedAtDesc(Pageable pageable);
+    Page<Diary> findAllByIdOrderByModifiedAtDesc(Pageable pageable, Long id);
+
 }

--- a/src/main/java/com/hanghae/sosohandiary/domain/invite/repository/InviteRepository.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/invite/repository/InviteRepository.java
@@ -3,7 +3,10 @@ package com.hanghae.sosohandiary.domain.invite.repository;
 import com.hanghae.sosohandiary.domain.invite.entity.Invite;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface InviteRepository extends JpaRepository<Invite, Long> {
 
     Long countByDiaryId(Long diaryId);
+    List<Invite> findAllByToMemberId(Long id);
 }


### PR DESCRIPTION
## 📕 제목
Feat: 메인페이지 - Private, Public 필터 페이지 만들기

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 작업내용1 : Public, Private으로 나뉘어진 다이어리를 따로 보여질 수 있게 구현
- [x] 작업내용2 :  초대된 다이어리도 나올 수 있게 구현
- [x] 작업내용3

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이사항1 : 없음