### PR TITLE
Fix: 속지 삭제 시 좋아요, 댓글도 삭제되도록 수정. #93

### DIFF
--- a/src/main/java/com/hanghae/sosohandiary/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/comment/repository/CommentRepository.java
@@ -9,4 +9,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByOrderByCreatedAtDesc();
 
     int countCommentsByDiaryDetailId(Long id);
+
+
+    void deleteAllByDiaryDetailId(Long detailId);
 }

--- a/src/main/java/com/hanghae/sosohandiary/domain/diarydetail/service/DiaryDetailService.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/diarydetail/service/DiaryDetailService.java
@@ -97,6 +97,12 @@ public class DiaryDetailService {
                 () -> new ApiException(ErrorHandling.NOT_FOUND_DIARY)
         );
 
+        if (commentRepository.countCommentsByDiaryDetailId(detailId) > 0) {
+            commentRepository.deleteAllByDiaryDetailId(detailId);
+        }
+        if (likesRepository.countByDiaryDetailId(detailId) > 0) {
+            likesRepository.deleteAllByDiaryDetailId(detailId);
+        }
         diaryDetailRepository.deleteById(detailId);
 
         return MessageDto.of("다이어리 삭제 완료", HttpStatus.OK);

--- a/src/main/java/com/hanghae/sosohandiary/domain/like/repository/LikesRepository.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/like/repository/LikesRepository.java
@@ -11,5 +11,7 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     int countByDiaryDetailId(Long id);
 
+    void deleteAllByDiaryDetailId(Long detailId);
+
     //Optional<Likes> findByDiaryIdAndDiaryDetailIdAndMemberId(Long diaryId, Long detailId, Long id);
 }


### PR DESCRIPTION
## 📕 제목
Fix: 속지 삭제 시 좋아요, 댓글도 삭제되도록 수정.
## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 작업내용1 : 속지 삭제될 때 해당 속지ID 기준 댓글 전체 삭제.
- [x] 작업내용2 : 속지 삭제될 때 해당 속지ID 기준 좋아요 전체 삭제.
