### PR TITLE
Fix: 회원탈퇴시 친구가 되어있는 멤버 삭제가 안되는 기능 수정 

### DIFF
--- a/src/main/java/com/hanghae/sosohandiary/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/diary/repository/DiaryRepository.java
@@ -18,5 +18,5 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Page<Diary> findAllByMemberIdAndDiaryConditionOrderByModifiedAtDesc(Pageable pageable, Long id, DiaryCondition condition);
     Page<Diary> findAllByOrderByModifiedAtDesc(Pageable pageable);
     Page<Diary> findAllByIdOrderByModifiedAtDesc(Pageable pageable, Long id);
-
+    void deleteAllByMemberId(Long id);
 }

--- a/src/main/java/com/hanghae/sosohandiary/domain/friend/entity/Friend.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/friend/entity/Friend.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -24,10 +26,12 @@ public class Friend extends Timestamp {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "friend_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member friend;
 
     @Column(name = "status")

--- a/src/main/java/com/hanghae/sosohandiary/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/friend/repository/FriendRepository.java
@@ -21,4 +21,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findByMemberIdAndStatusOrderByFriendNicknameAsc(Long id, StatusFriend Status);
 
     List<Friend> findByFriendIdAndStatusOrderByCreatedAtDesc(Long id, StatusFriend Status);
+
+    void deleteAllByFriendId(Long id);
 }

--- a/src/main/java/com/hanghae/sosohandiary/domain/invite/repository/InviteRepository.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/invite/repository/InviteRepository.java
@@ -9,4 +9,5 @@ public interface InviteRepository extends JpaRepository<Invite, Long> {
 
     Long countByDiaryId(Long diaryId);
     List<Invite> findAllByToMemberId(Long id);
+    void deleteAllByToMemberId(Long id);
 }

--- a/src/main/java/com/hanghae/sosohandiary/domain/mypage/service/MypageService.java
+++ b/src/main/java/com/hanghae/sosohandiary/domain/mypage/service/MypageService.java
@@ -5,6 +5,7 @@ import com.hanghae.sosohandiary.domain.diary.entity.Diary;
 import com.hanghae.sosohandiary.domain.diary.repository.DiaryRepository;
 import com.hanghae.sosohandiary.domain.diary.service.DiaryService;
 import com.hanghae.sosohandiary.domain.friend.entity.Friend;
+import com.hanghae.sosohandiary.domain.invite.repository.InviteRepository;
 import com.hanghae.sosohandiary.domain.member.dto.MemberResponseDto;
 import com.hanghae.sosohandiary.domain.member.entity.Member;
 import com.hanghae.sosohandiary.domain.member.repository.MemberRepository;
@@ -35,6 +36,7 @@ public class MypageService {
     private final DiaryService diaryService;
     private final DiaryRepository diaryRepository;
     private final FriendRepository friendsRepository;
+    private final InviteRepository inviteRepository;
 
     public MypageProfileResponseDto getProfile(Member member) {
 
@@ -76,6 +78,9 @@ public class MypageService {
         }
 
         memberRepository.deleteById(member.getId());
+        diaryRepository.deleteAllByMemberId(member.getId());
+        friendsRepository.deleteAllByFriendId(member.getId());
+        inviteRepository.deleteAllByToMemberId(member.getId());
 
         return MessageDto.of("회원 탈퇴 성공", HttpStatus.ACCEPTED);
     }


### PR DESCRIPTION
## 📕 제목
회원탈퇴시 친구가 되어있는 멤버 삭제가 안되는 기능 수정

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 작업내용1 : 친구가 되어있는 멤버 회원탈퇴 진행 시 회원탈퇴 가능토록 수정
- [x] 작업내용2 : 회원을 탈퇴하고자 하는 멤버의 모든 데이터들 삭제

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이사항1 : 없음